### PR TITLE
feat(search): Add medicine search

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,4 @@
+DB_URL=mongodb://localhost:27017/
+DB_HOST=mongodb
+DB_PORT=27017
+DB_NAME=ess-backend-db

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,2 @@
 __pycache__
 .pytest_cache
-.env

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,6 @@ pytest
 pytest-mongodb
 pytest-bdd
 httpx
+bcrypt
+passlib
+jwt

--- a/backend/src/api/medicine.py
+++ b/backend/src/api/medicine.py
@@ -147,3 +147,35 @@ def update_medicine(name: str, medicine_data: MedicineUpdateModel, current_user:
     medicine_data = medicine_data.model_dump()
     medicine_data = {key: value for key, value in medicine_data.items() if value is not None}
     return MedicineService.update_medicine(name, medicine_data)
+
+@router.get(
+    "/search/{name_pattern}",
+    response_model=HttpResponseModel,
+    status_code=status.HTTP_200_OK,
+    description="Search for medicines by name pattern",
+    tags=["medicine"],
+    responses={
+        status.HTTP_200_OK: {
+            "model": HttpResponseModel,
+            "description": "Successfully found medicines matching the pattern",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "No medicines found matching the pattern",
+        },
+    },
+)
+def search_medicine(name_pattern: str, current_user: dict = Depends(get_current_user)) -> HttpResponseModel:
+    """
+    Search for medicines by name pattern.
+    
+    Parameters:
+    - name_pattern: The regex pattern to match medicine names.
+    
+    Returns:
+    - A list of medicines matching the pattern.
+    
+    Raises:
+    - HTTPException 404: If no medicines match the pattern.
+    """
+    return MedicineService.search_medicine(name_pattern)
+

--- a/backend/src/db/database.py
+++ b/backend/src/db/database.py
@@ -4,6 +4,7 @@ from pymongo import MongoClient, errors
 from pymongo.collection import Collection, IndexModel
 from src.config.config import env
 from logging import INFO, WARNING, getLogger
+from src.db.serializers.medicine_serialize import medicines_list_entity
 
 logger = getLogger('uvicorn')
 
@@ -465,3 +466,21 @@ class Database():
 
         updated_data["id"] = medicine_name 
         return {"status": "success", "message": "medicine updated successfully", "data": updated_data}
+
+    def search_medicine(self, collection_name: str, name_pattern: str) -> list:
+        """
+        Search for medicines by name using a regex pattern
+
+        Parameters:
+        - collection_name: str
+            The name of the collection where the medicines are stored
+        - name_pattern: str
+            The regex pattern to match medicine names
+
+        Returns:
+        - list:
+            A list of serialized medicines matching the regex pattern
+        """
+        collection: Collection = self.db[collection_name]
+        medicines = list(collection.find({"name": {"$regex": name_pattern, "$options": "i"}}, {"_id": 0}))
+        return medicines_list_entity(medicines)

--- a/backend/src/db/serializers/medicine_serialize.py
+++ b/backend/src/db/serializers/medicine_serialize.py
@@ -1,0 +1,14 @@
+def medicine_search_entity(item) -> dict:
+    """
+    Returns a dict of the medicine entity with selected attributes
+    """
+    return {
+        "name": item["name"],
+        "dosage": item["dosage"],
+    }
+
+def medicines_list_entity(items) -> list:
+    """
+    Returns a list of serialized medicine entities
+    """
+    return [medicine_search_entity(item) for item in items]

--- a/backend/src/service/impl/medicine_service.py
+++ b/backend/src/service/impl/medicine_service.py
@@ -1,6 +1,7 @@
 from src.schemas.response import HTTPResponses, HttpResponseModel
 from src.service.meta.item_service_meta import ItemServiceMeta
 from src.db.__init__ import database as db
+from src.db.serializers.medicine_serialize import medicines_list_entity
 
 class MedicineService(ItemServiceMeta):
 
@@ -74,4 +75,20 @@ class MedicineService(ItemServiceMeta):
         return HttpResponseModel(
             message=HTTPResponses.MEDICINE_NOT_FOUND().message,
             status_code=HTTPResponses.MEDICINE_NOT_FOUND().status_code,
+        )
+
+    @staticmethod
+    def search_medicine(name_pattern: str) -> HttpResponseModel:
+        """Search for medicines by name pattern"""
+        medicines = db.search_medicine('medicine', name_pattern)
+        if not medicines:
+            return HttpResponseModel(
+                message=HTTPResponses.MEDICINE_NOT_FOUND().message,
+                status_code=HTTPResponses.MEDICINE_NOT_FOUND().status_code,
+            )
+        serialized_medicines = medicines_list_entity(medicines)
+        return HttpResponseModel(
+            message=HTTPResponses.MEDICINE_FOUND().message,
+            status_code=HTTPResponses.MEDICINE_FOUND().status_code,
+            data=serialized_medicines,
         )


### PR DESCRIPTION
## Purpose: 
Implement the medicine search through regex feature in the backend, which should be used in the frontend's medicine search bar
## What I've Done: 
- Created the medicine search in the database functions, service implementations and api definitions
- Tested the functionality to ensure proper behavior. 
- Also added some non-included dependencies to `requirements.txt` and removed `.env` from `.gitignore`
## How to test 
- Log into the backend
- Access the `/medicine/search/{query}` endpoint, where "query" is the string that will be used to regex match with the names in the database. The return should either be a "Medicine Not Found" message, or a "Medicine Found" with a list of dicts containing the medicine names and dosages.
- Example:  `http://127.0.0.1:8000/medicine/search/Para` returns `{"message":"MEDICINE found","status_code":200,"data":[{"name":"Paracetamol","dosage":"500mg"}]}`